### PR TITLE
fix: invalid path for the bundle.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add this to your `tsconfig.json` or `jsconfig.json`:
 
 # Contributing
 
-`bun-types` is generated via [./bundle.ts](./bundle.ts).
+`bun-types` is generated via [./bundle.ts](./scripts/bundle.ts).
 
 ## Adding a new file
 


### PR DESCRIPTION
the path for the bundle.ts was incorrrect, 
``bun-types` is generated via [./bundle.ts](./scripts/bundle.ts).`
i update it to this