### PR TITLE
Update link to jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ bun generate:package
 
 # Generated docs
 
-**[📚 See here for docs](./docs/modules.md#bun-types)**
+**[📚 See here for docs](https://oven-sh.github.io/bun-types/)**


### PR DESCRIPTION
Fix typo-- docs link in main README now points to jekyll (rather than markdown/repo hosting strategy)

@xHyroM is this is a good/stable link? https://oven-sh.github.io/bun-types