### PR TITLE
Add base64 as valid BufferEncoding

### DIFF
--- a/bun.d.ts
+++ b/bun.d.ts
@@ -1329,7 +1329,8 @@ type BufferEncoding =
   | "latin1"
   | "binary"
   | "hex"
-  | "base64";
+  | "base64"
+  | "base64url";
 
 interface BufferEncodingOption {
   encoding?: BufferEncoding;

--- a/bun.d.ts
+++ b/bun.d.ts
@@ -1328,7 +1328,8 @@ type BufferEncoding =
   | "ucs-2"
   | "latin1"
   | "binary"
-  | "hex";
+  | "hex"
+  | "base64";
 
 interface BufferEncodingOption {
   encoding?: BufferEncoding;


### PR DESCRIPTION
This PR adds `base64` as a BufferEncoding. This resolves #12